### PR TITLE
Fix image validation to use main branch tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,22 +97,9 @@ jobs:
     needs: docker
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     steps:
-    - name: Extract metadata
-      id: meta
-      uses: docker/metadata-action@v5
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        tags: |
-          type=ref,event=branch
-          type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=sha,prefix=sha-
-
     - name: Test Docker image
       run: |
-        # Get the first tag from the metadata
-        IMAGE_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n1)
+        IMAGE_TAG="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:main"
         echo "Testing image: $IMAGE_TAG"
         
         # Test help command


### PR DESCRIPTION
## Summary
Fixes the image validation step that was failing due to tag mismatches by using the predictable `main` branch tag instead of recreating metadata.

## Changes
- Remove duplicate metadata extraction in validate-image job
- Use hardcoded `main` tag since job only runs on main branch pushes
- Simplifies validation logic and prevents tag mismatch errors

## Test plan
- [x] Verify workflow syntax is valid
- [ ] Test that image validation uses correct main branch tag
- [ ] Confirm validation job runs only on main branch pushes

🤖 Generated with [Claude Code](https://claude.ai/code)